### PR TITLE
Add support for CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,10 +15,11 @@ image.uf2
 *.d
 
 # Exclude build directories and host executables
-miosix/_tools/filesystems/build
 miosix/_tools/filesystems/buildromfs
-miosix/_tools/bin2uf2/build
 miosix/_tools/bin2uf2/bin2uf2
+
+# Exclude all build directories
+build
 
 # Exclude Mac OS X temporary
 ._*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,45 @@
+# Copyright (C) 2024 by Skyward
+#
+# This program is free software; you can redistribute it and/or
+# it under the terms of the GNU General Public License as published
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# As a special exception, if other files instantiate templates or use
+# macros or inline functions from this file, or you compile this file
+# and link it with other works to produce a work based on this file,
+# this file does not by itself cause the resulting work to be covered
+# by the GNU General Public License. However the source code for this
+# file must still be made available in accordance with the GNU
+# Public License. This exception does not invalidate any other
+# why a work based on this file might be covered by the GNU General
+# Public License.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+
+cmake_minimum_required(VERSION 3.16)
+
+project(Main C CXX ASM)
+
+# Set here your board of choice
+set(MIOSIX_OPT_BOARD NOT_SET CACHE STRING "Target board")
+
+add_subdirectory(miosix EXCLUDE_FROM_ALL)
+include(LinkTarget)
+
+# List here your source files (.s, .c and .cpp)
+add_executable(main main.cpp)
+miosix_link_target(main)
+miosix_add_program_target(main)
+
+# List here additional include directories
+# target_include_directories(main PRIVATE here_your_includes)
+
+# List here additional static libraries
+# target_link_libraries(main PRIVATE here_your_libraries)

--- a/miosix/CMakeLists.txt
+++ b/miosix/CMakeLists.txt
@@ -1,0 +1,152 @@
+# Copyright (C) 2024 by Skyward
+#
+# This program is free software; you can redistribute it and/or
+# it under the terms of the GNU General Public License as published
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# As a special exception, if other files instantiate templates or use
+# macros or inline functions from this file, or you compile this file
+# and link it with other works to produce a work based on this file,
+# this file does not by itself cause the resulting work to be covered
+# by the GNU General Public License. However the source code for this
+# file must still be made available in accordance with the GNU
+# Public License. This exception does not invalidate any other
+# why a work based on this file might be covered by the GNU General
+# Public License.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+
+cmake_minimum_required(VERSION 3.16)
+
+project(Miosix
+    VERSION 2.7
+    DESCRIPTION "OS kernel designed to run on 32bit microcontrollers."
+    HOMEPAGE_URL "https://miosix.org"
+    LANGUAGES C CXX
+)
+
+set(MIOSIX_KPATH ${CMAKE_CURRENT_LIST_DIR} CACHE PATH "Path to the miosix kernel")
+
+set(MIOSIX_KERNEL_SRC
+    ${MIOSIX_KPATH}/kernel/kernel.cpp
+    ${MIOSIX_KPATH}/kernel/sync.cpp
+    ${MIOSIX_KPATH}/kernel/error.cpp
+    ${MIOSIX_KPATH}/kernel/pthread.cpp
+    ${MIOSIX_KPATH}/kernel/boot.cpp
+    ${MIOSIX_KPATH}/kernel/elf_program.cpp
+    ${MIOSIX_KPATH}/kernel/process.cpp
+    ${MIOSIX_KPATH}/kernel/process_pool.cpp
+    ${MIOSIX_KPATH}/kernel/timeconversion.cpp
+    ${MIOSIX_KPATH}/kernel/intrusive.cpp
+    ${MIOSIX_KPATH}/kernel/cpu_time_counter.cpp
+    ${MIOSIX_KPATH}/kernel/scheduler/priority/priority_scheduler.cpp
+    ${MIOSIX_KPATH}/kernel/scheduler/control/control_scheduler.cpp
+    ${MIOSIX_KPATH}/kernel/scheduler/edf/edf_scheduler.cpp
+    ${MIOSIX_KPATH}/filesystem/file_access.cpp
+    ${MIOSIX_KPATH}/filesystem/file.cpp
+    ${MIOSIX_KPATH}/filesystem/path.cpp
+    ${MIOSIX_KPATH}/filesystem/stringpart.cpp
+    ${MIOSIX_KPATH}/filesystem/pipe/pipe.cpp
+    ${MIOSIX_KPATH}/filesystem/console/console_device.cpp
+    ${MIOSIX_KPATH}/filesystem/mountpointfs/mountpointfs.cpp
+    ${MIOSIX_KPATH}/filesystem/devfs/devfs.cpp
+    ${MIOSIX_KPATH}/filesystem/fat32/fat32.cpp
+    ${MIOSIX_KPATH}/filesystem/fat32/ff.cpp
+    ${MIOSIX_KPATH}/filesystem/fat32/diskio.cpp
+    ${MIOSIX_KPATH}/filesystem/fat32/wtoupper.cpp
+    ${MIOSIX_KPATH}/filesystem/fat32/ccsbcs.cpp
+    ${MIOSIX_KPATH}/filesystem/littlefs/lfs_miosix.cpp
+    ${MIOSIX_KPATH}/filesystem/littlefs/lfs.c
+    ${MIOSIX_KPATH}/filesystem/littlefs/lfs_util.c
+    ${MIOSIX_KPATH}/filesystem/romfs/romfs.cpp
+    ${MIOSIX_KPATH}/stdlib_integration/libc_integration.cpp
+    ${MIOSIX_KPATH}/stdlib_integration/libstdcpp_integration.cpp
+    ${MIOSIX_KPATH}/e20/e20.cpp
+    ${MIOSIX_KPATH}/e20/unmember.cpp
+    ${MIOSIX_KPATH}/util/util.cpp
+    ${MIOSIX_KPATH}/util/unicode.cpp
+    ${MIOSIX_KPATH}/util/version.cpp
+    ${MIOSIX_KPATH}/util/crc16.cpp
+    ${MIOSIX_KPATH}/util/lcd44780.cpp
+)
+
+# Include the architecture options
+include(${MIOSIX_KPATH}/arch/CMakeLists.txt)
+
+# Verify that all the required variables have been defined, otherwise abort
+set(REQUIRED_VARIABLES
+    MIOSIX_OPT_BOARD
+    MIOSIX_ARCH_INC
+    MIOSIX_BOARD_INC
+    MIOSIX_BOARD_SETTINGS_INC
+    MIOSIX_LINKER_SCRIPT
+    MIOSIX_A_FLAGS
+    MIOSIX_C_FLAGS
+    MIOSIX_CXX_FLAGS
+    MIOSIX_L_FLAGS
+    MIOSIX_ARCH_SRC
+)
+foreach(VARIABLE ${REQUIRED_VARIABLES})
+    if(NOT DEFINED ${VARIABLE})
+        message(FATAL_ERROR "arch/CMakeLists.txt must define ${VARIABLE}")
+    endif()
+endforeach()
+
+# The user can set a custom path for miosix_settings.h
+set(MIOSIX_SETTINGS_PATH ${MIOSIX_KPATH}/default CACHE PATH "Include directory for miosix_settings.h")
+mark_as_advanced(MIOSIX_SETTINGS_PATH)
+if(NOT MIOSIX_SETTINGS_PATH STREQUAL ${MIOSIX_KPATH}/default)
+    message(NOTICE "You have set a custom path for miosix_settings.h")
+endif()
+
+# Define the miosix library with kernel and architecture sources
+add_library(miosix STATIC ${MIOSIX_KERNEL_SRC} ${MIOSIX_ARCH_SRC})
+
+target_include_directories(miosix PUBLIC
+    ${MIOSIX_KPATH}
+    ${MIOSIX_KPATH}/arch/common
+    ${MIOSIX_ARCH_INC}
+    ${MIOSIX_BOARD_INC}
+    ${MIOSIX_BOARD_SETTINGS_INC}
+    ${MIOSIX_SETTINGS_PATH}
+)
+
+target_compile_options(miosix PUBLIC
+    $<$<COMPILE_LANGUAGE:ASM>:${MIOSIX_A_FLAGS}>
+    $<$<COMPILE_LANGUAGE:C>:${MIOSIX_C_FLAGS}>
+    $<$<COMPILE_LANGUAGE:CXX>:${MIOSIX_CXX_FLAGS}>
+)
+
+# Configure program command as a propery of the miosix library
+set_property(TARGET miosix PROPERTY PROGRAM_CMDLINE ${PROGRAM_CMDLINE})
+
+# Add COMPILING_MIOSIX define for private headers
+target_compile_definitions(miosix PRIVATE $<$<COMPILE_LANGUAGE:C,CXX>:COMPILING_MIOSIX>)
+
+# Configure linker file and options needed to link agains this library
+set_property(TARGET miosix PROPERTY LINK_DEPENDS ${MIOSIX_BOARD_INC}/${MIOSIX_LINKER_SCRIPT})
+target_link_options(miosix INTERFACE ${MIOSIX_L_FLAGS})
+
+# Run the kernel_global_objects.pl script on all kernel objects
+add_custom_command(
+    TARGET miosix PRE_LINK
+    COMMAND perl ${MIOSIX_KPATH}/_tools/kernel_global_objects.pl $<TARGET_OBJECTS:miosix>
+    VERBATIM
+    COMMAND_EXPAND_LISTS
+)
+
+# Optionally print the board list
+option(MIOSIX_PRINT_BOARD_LIST "Prints a list of the available boards" OFF)
+if(MIOSIX_PRINT_BOARD_LIST)
+    message(STATUS "Available boards:")
+    foreach(MIOSIX_OPT_BOARD ${MIOSIX_BOARDS})
+        message(STATUS "\t${MIOSIX_OPT_BOARD}")
+    endforeach()
+endif()

--- a/miosix/_examples/blinking_led/CMakeLists.txt
+++ b/miosix/_examples/blinking_led/CMakeLists.txt
@@ -1,0 +1,40 @@
+# Copyright (C) 2024 by Skyward
+#
+# This program is free software; you can redistribute it and/or
+# it under the terms of the GNU General Public License as published
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# As a special exception, if other files instantiate templates or use
+# macros or inline functions from this file, or you compile this file
+# and link it with other works to produce a work based on this file,
+# this file does not by itself cause the resulting work to be covered
+# by the GNU General Public License. However the source code for this
+# file must still be made available in accordance with the GNU
+# Public License. This exception does not invalidate any other
+# why a work based on this file might be covered by the GNU General
+# Public License.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+
+cmake_minimum_required(VERSION 3.16)
+
+project(BlinkingLED C CXX ASM)
+
+# Set Miosix definitions and options
+add_compile_definitions($<$<COMPILE_LANGUAGE:C,CXX>:MIOSIX_SKIP_SETTINGS_EDIT>)
+set(MIOSIX_OPT_BOARD stm32f429zi_stm32f4discovery CACHE STRING "Target board")
+
+add_subdirectory(../.. miosix EXCLUDE_FROM_ALL)
+
+include(LinkTarget)
+
+add_executable(blinking_led simple.cpp)
+miosix_link_target(blinking_led)
+miosix_add_program_target(blinking_led)

--- a/miosix/_examples/blinking_led/simple.cpp
+++ b/miosix/_examples/blinking_led/simple.cpp
@@ -1,24 +1,22 @@
 #include <cstdio>
-#include <unistd.h>
+
+#include "interfaces/bsp.h"
 #include "miosix.h"
 
-using namespace std;
 using namespace miosix;
-
-typedef Gpio<GPIOC_BASE,7>  led;
 
 int main()
 {
-  
-  led::mode(Mode::OUTPUT);
-  
-  for(;;) {
-    led::high();
-    sleep(1);
-    led::low();
-    sleep(1);
-  }
-  
-  return 0;
-  
+    while(true)
+    {
+        ledOn();
+        printf("Led on\n");
+        sleep(1);
+
+        ledOff();
+        printf("Led off\n");
+        sleep(1);
+    }
+
+    return 0;
 }

--- a/miosix/_examples/processes/CMakeLists.txt
+++ b/miosix/_examples/processes/CMakeLists.txt
@@ -1,0 +1,58 @@
+# Copyright (C) 2024 by Skyward
+#
+# This program is free software; you can redistribute it and/or
+# it under the terms of the GNU General Public License as published
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# As a special exception, if other files instantiate templates or use
+# macros or inline functions from this file, or you compile this file
+# and link it with other works to produce a work based on this file,
+# this file does not by itself cause the resulting work to be covered
+# by the GNU General Public License. However the source code for this
+# file must still be made available in accordance with the GNU
+# Public License. This exception does not invalidate any other
+# why a work based on this file might be covered by the GNU General
+# Public License.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+
+cmake_minimum_required(VERSION 3.16)
+
+project(ProcessesExamples C CXX ASM)
+
+# Set Miosix definitions and options
+add_compile_definitions($<$<COMPILE_LANGUAGE:C,CXX>:MIOSIX_SKIP_SETTINGS_EDIT>)
+add_compile_definitions($<$<COMPILE_LANGUAGE:C,CXX>:WITH_PROCESSES>)
+set(MIOSIX_OPT_BOARD stm32f429zi_stm32f4discovery CACHE STRING "Target board")
+set(MIOSIX_LINKER_SCRIPT stm32_2m+256k_rom_processes.ld CACHE FILEPATH "Linker script")
+
+add_subdirectory(../.. miosix EXCLUDE_FROM_ALL)
+add_subdirectory(../../libsyscalls libsyscalls EXCLUDE_FROM_ALL)
+
+include(LinkTarget)
+include(AddProcess)
+include(AddRomfsImage)
+
+# Kernel level program
+add_executable(main main.cpp)
+miosix_link_target(main)
+
+# Processes
+miosix_add_process(process1 process1.cpp)
+miosix_add_process(process2 process2.cpp)
+
+# RomFS image
+miosix_add_romfs_image(
+    IMAGE_NAME image
+    DIR_NAME bin
+    KERNEL main
+    PROCESSES process1 process2
+)
+miosix_add_program_target(image DEPENDS image)

--- a/miosix/_examples/processes/main.cpp
+++ b/miosix/_examples/processes/main.cpp
@@ -1,0 +1,36 @@
+#include <spawn.h>
+#include <sys/wait.h>
+
+#include <cstdio>
+
+void start_process(pid_t* pid, char* const argv[], char* const envp[])
+{
+    int error_code = posix_spawn(pid, argv[0], NULL, NULL, argv, envp);
+
+    if(error_code != 0)
+    {
+        printf("spawn returned %d\n", error_code);
+    }
+}
+
+int main()
+{
+    pid_t pid1, pid2;
+
+    // Arguments and environment variables
+    const char* arg1[] = {"/bin/process1", nullptr};
+    const char* arg2[] = {"/bin/process2", nullptr};
+    const char* env[]  = {nullptr};
+
+    // Start the processes
+    start_process(&pid1, (char* const*)arg1, (char* const*)env);
+    start_process(&pid2, (char* const*)arg2, (char* const*)env);
+
+    // Wait for them to end
+    wait(NULL);
+    wait(NULL);
+
+    printf("All processes ended\n");
+
+    return 0;
+}

--- a/miosix/_examples/processes/process1.cpp
+++ b/miosix/_examples/processes/process1.cpp
@@ -1,0 +1,17 @@
+#include <cstdio>
+#include <ctime>
+
+int main()
+{
+    printf("Hi! I'm the process #1\n");
+
+    printf("I'll count to 10\n");
+    const timespec sleep_time{.tv_sec = 1, .tv_nsec = 0};
+    for (int i = 1; i <= 10; i++)
+    {
+        nanosleep(&sleep_time, NULL);
+        printf("%d\n", i);
+    }
+
+    return 0;
+}

--- a/miosix/_examples/processes/process2.cpp
+++ b/miosix/_examples/processes/process2.cpp
@@ -1,0 +1,17 @@
+#include <cstdio>
+#include <ctime>
+
+int main()
+{
+    printf("Hi! I'm the process #2\n");
+
+    printf("I'll write 10 letters\n");
+    const timespec sleep_time{.tv_sec = 1, .tv_nsec = 0};
+    for (int i = 1; i <= 10; i++)
+    {
+        nanosleep(&sleep_time, NULL);
+        printf("%c\n", 'Z' - i);
+    }
+
+    return 0;
+}

--- a/miosix/_tools/build_test.sh
+++ b/miosix/_tools/build_test.sh
@@ -1,0 +1,39 @@
+#! /bin/bash
+
+MIOSIX_KPATH=$(dirname $(dirname $(realpath $BASH_SOURCE)))
+
+build_program() {
+    rm -rf $1/build
+    cmake -S $1 -B $1/build $2 --toolchain $MIOSIX_KPATH/cmake/Toolchains/gcc.cmake > /dev/null
+    cmake --build $1/build -j 16 > /dev/null
+}
+
+# Try to build all available programs in _examples and _tools
+echo "Building all available programs"
+for file in $(find $MIOSIX_KPATH/_tools $MIOSIX_KPATH/_examples -name CMakeLists.txt); do
+    # Check if the CMakeLists.txt is for a miosix program
+    if grep -q "miosix_link_target" $file; then
+        file=$(dirname $file)
+        echo "  Building program in $file"
+        build_program $file
+    fi
+done
+
+# Try to compile the blinking_led test for every supported board
+declare -a boards=(
+    "stm32f407vg_stm32f4discovery stm32_1m+192k_rom.ld"
+    "stm32f407vg_stm32f4discovery stm32_1m+192k_rom_processes.ld"
+    "stm32f429zi_stm32f4discovery stm32_2m+256k_rom.ld"
+    "stm32f429zi_stm32f4discovery stm32_2m+256k_ro_processes.ld"
+    "stm32f429zi_stm32f4discovery stm32_2m+6m_xram.ld"
+    "stm32f429zi_stm32f4discovery stm32_2m+8m_xram.ld"
+    "stm32f767zi_nucleo stm32_2m+384k_ram.ld"
+    "stm32f767zi_nucleo stm32_2m+384k_ram_processes.ld"
+)
+echo "Building testsuite for all available boards"
+dir=$MIOSIX_KPATH/_tools/testsuite
+for board in "${boards[@]}"; do
+    read -a board <<< "$board"
+    echo "  board=${board[0]} linker_script=${board[1]}"
+    build_program $dir "-DMIOSIX_OPT_BOARD=${board[0]} -DMIOSIX_LINKER_SCRIPT=${board[1]}"
+done

--- a/miosix/_tools/processes/CMakeLists.txt
+++ b/miosix/_tools/processes/CMakeLists.txt
@@ -1,0 +1,58 @@
+# Copyright (C) 2024 by Skyward
+#
+# This program is free software; you can redistribute it and/or
+# it under the terms of the GNU General Public License as published
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# As a special exception, if other files instantiate templates or use
+# macros or inline functions from this file, or you compile this file
+# and link it with other works to produce a work based on this file,
+# this file does not by itself cause the resulting work to be covered
+# by the GNU General Public License. However the source code for this
+# file must still be made available in accordance with the GNU
+# Public License. This exception does not invalidate any other
+# why a work based on this file might be covered by the GNU General
+# Public License.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+
+cmake_minimum_required(VERSION 3.16)
+
+project(ProcessesExamples C CXX ASM)
+
+# Set Miosix definitions and options
+add_compile_definitions($<$<COMPILE_LANGUAGE:C,CXX>:MIOSIX_SKIP_SETTINGS_EDIT>)
+add_compile_definitions($<$<COMPILE_LANGUAGE:C,CXX>:WITH_PROCESSES>)
+set(MIOSIX_OPT_BOARD stm32f429zi_stm32f4discovery CACHE STRING "Target board")
+set(MIOSIX_LINKER_SCRIPT stm32_2m+256k_rom_processes.ld CACHE FILEPATH "Linker script")
+
+add_subdirectory(../.. miosix EXCLUDE_FROM_ALL)
+add_subdirectory(../../libsyscalls libsyscalls EXCLUDE_FROM_ALL)
+
+include(LinkTarget)
+include(AddProcess)
+include(AddRomfsImage)
+
+# Kernel level program
+add_executable(main start_process.cpp)
+miosix_link_target(main)
+
+# Processes
+miosix_add_process(hello process_template/main.cpp)
+
+# RomFS image
+#
+miosix_add_romfs_image(
+    IMAGE_NAME image
+    DIR_NAME bin
+    KERNEL main
+    PROCESSES hello
+)
+miosix_add_program_target(image DEPENDS image)

--- a/miosix/_tools/testsuite/CMakeLists.txt
+++ b/miosix/_tools/testsuite/CMakeLists.txt
@@ -1,0 +1,60 @@
+# Copyright (C) 2024 by Skyward
+#
+# This program is free software; you can redistribute it and/or
+# it under the terms of the GNU General Public License as published
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# As a special exception, if other files instantiate templates or use
+# macros or inline functions from this file, or you compile this file
+# and link it with other works to produce a work based on this file,
+# this file does not by itself cause the resulting work to be covered
+# by the GNU General Public License. However the source code for this
+# file must still be made available in accordance with the GNU
+# Public License. This exception does not invalidate any other
+# why a work based on this file might be covered by the GNU General
+# Public License.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+
+cmake_minimum_required(VERSION 3.16)
+
+project(ProcessesExamples C CXX ASM)
+
+# Set Miosix definitions and options
+add_compile_definitions($<$<COMPILE_LANGUAGE:C,CXX>:MIOSIX_SKIP_SETTINGS_EDIT>)
+# add_compile_definitions($<$<COMPILE_LANGUAGE:C,CXX>:WITH_PROCESSES>)
+set(MIOSIX_OPT_BOARD stm32f767zi_nucleo CACHE STRING "Target board")
+set(MIOSIX_LINKER_SCRIPT stm32_2m+384k_ram_processes.ld CACHE FILEPATH "Linker script")
+
+add_subdirectory(../.. miosix EXCLUDE_FROM_ALL)
+add_subdirectory(../../libsyscalls libsyscalls EXCLUDE_FROM_ALL)
+
+include(LinkTarget)
+include(AddProcess)
+include(AddRomfsImage)
+
+# Kernel level program
+add_executable(testsuite testsuite.cpp)
+miosix_link_target(testsuite)
+miosix_add_program_target(testsuite)
+
+# Processes
+# miosix_add_process(test_process test_process/main.cpp)
+# miosix_add_process(test_execve test_execve/main.cpp)
+# miosix_add_process(test_global_dtor_ctor test_global_dtor_ctor/main.cpp)
+
+# RomFS image
+# miosix_add_romfs_image(
+#     IMAGE_NAME image
+#     DIR_NAME bin
+#     KERNEL testsuite
+#     PROCESSES test_process # test_execve test_global_dtor_ctor
+# )
+# miosix_add_program_target(image)

--- a/miosix/arch/CMakeLists.txt
+++ b/miosix/arch/CMakeLists.txt
@@ -1,0 +1,84 @@
+# Copyright (C) 2024 by Skyward
+#
+# This program is free software; you can redistribute it and/or
+# it under the terms of the GNU General Public License as published
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# As a special exception, if other files instantiate templates or use
+# macros or inline functions from this file, or you compile this file
+# and link it with other works to produce a work based on this file,
+# this file does not by itself cause the resulting work to be covered
+# by the GNU General Public License. However the source code for this
+# file must still be made available in accordance with the GNU
+# Public License. This exception does not invalidate any other
+# why a work based on this file might be covered by the GNU General
+# Public License.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+
+set(MIOSIX_BOARDS
+    stm32f407vg_stm32f4discovery
+    stm32f429zi_stm32f4discovery
+    stm32f767zi_nucleo
+)
+
+# Target board option, this also implicitly select the target architecture
+set(MIOSIX_OPT_BOARD NOT_SET CACHE STRING "Target board")
+set_property(CACHE MIOSIX_OPT_BOARD PROPERTY STRINGS ${MIOSIX_BOARDS})
+if(MIOSIX_OPT_BOARD STREQUAL NOT_SET)
+    message(FATAL_ERROR "You must specify a target board with MIOSIX_OPT_BOARD")
+elseif(NOT MIOSIX_OPT_BOARD IN_LIST MIOSIX_BOARDS)
+    message(FATAL_ERROR "Selected board is not in the MIOSIX_BOARDS list")
+    message(MIOSIX_BOARDS)
+endif()
+
+# Optimization flags are set with CMAKE_<LANG>_FLAGS_<CONFIG>
+# The default values are in the toolchain file
+
+# C++ Exception/rtti support disable flags.
+# To save code size if not using C++ exceptions (nor some STL code which
+# implicitly uses it) uncomment this option.
+# -D__NO_EXCEPTIONS is used by Miosix to know if exceptions are used.
+option(MIOSIX_DISABLE_EXEPTIONS "Disables C++ exceptions/rtti support" OFF)
+if(MIOSIX_DISABLE_EXEPTIONS)
+    set(MIOSIX_OPT_EXCEPT -fno-exceptions -fno-rtti -D__NO_EXCEPTIONS)
+endif()
+
+# Auto guess architecture name from board name
+if(
+    MIOSIX_OPT_BOARD STREQUAL stm32f407vg_stm32f4discovery OR
+    MIOSIX_OPT_BOARD STREQUAL stm32f429zi_stm32f4discovery
+)
+    set(MIOSIX_ARCH_NAME cortexM4_stm32f4)
+elseif(
+    MIOSIX_OPT_BOARD STREQUAL stm32f767zi_nucleo
+)
+    set(MIOSIX_ARCH_NAME cortexM7_stm32f7)
+else()
+    message(FATAL_ERROR "Unknown architecture for board ${MIOSIX_OPT_BOARD}")
+endif()
+
+# Then, initialize C/C++ flags
+set(MIOSIX_C_FLAGS
+    -D_MIOSIX_BOARDNAME="${MIOSIX_OPT_BOARD}" -D_DEFAULT_SOURCE=1
+    -ffunction-sections -Wall -Werror=return-type -g
+)
+set(MIOSIX_CXX_FLAGS
+    -D_MIOSIX_BOARDNAME="${MIOSIX_OPT_BOARD}" -D_DEFAULT_SOURCE=1
+    -std=c++14 -ffunction-sections -Wall -Werror=return-type -g
+)
+
+# Now include the architecture specific CMakeLists that will:
+# - Sets common things for all boards of that specific architecture
+# - Includes the board specific CMakeLists file
+include(${MIOSIX_KPATH}/arch/${MIOSIX_ARCH_NAME}/CMakeLists.txt)
+
+# Same for CPU microarchitecture
+include(${MIOSIX_KPATH}/arch/cpu/CMakeLists.txt)

--- a/miosix/arch/cortexM4_stm32f4/CMakeLists.txt
+++ b/miosix/arch/cortexM4_stm32f4/CMakeLists.txt
@@ -1,0 +1,65 @@
+# Copyright (C) 2024 by Skyward
+#
+# This program is free software; you can redistribute it and/or
+# it under the terms of the GNU General Public License as published
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# As a special exception, if other files instantiate templates or use
+# macros or inline functions from this file, or you compile this file
+# and link it with other works to produce a work based on this file,
+# this file does not by itself cause the resulting work to be covered
+# by the GNU General Public License. However the source code for this
+# file must still be made available in accordance with the GNU
+# Public License. This exception does not invalidate any other
+# why a work based on this file might be covered by the GNU General
+# Public License.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+
+# CPU microarchitecture
+set(MIOSIX_CPU_MICROARCH armv7m)
+
+# Base directory with common header files for this board
+set(MIOSIX_ARCH_INC ${MIOSIX_KPATH}/arch/${MIOSIX_ARCH_NAME}/common)
+
+# Include board specific options
+include(${MIOSIX_KPATH}/arch/${MIOSIX_ARCH_NAME}/${MIOSIX_OPT_BOARD}/CMakeLists.txt)
+
+# Automatically transform the architecture name into upper cases
+string(TOUPPER ${MIOSIX_ARCH_NAME} MIOSIX_ARCH_NAME_UPPER)
+
+# Select appropriate compiler flags for both ASM/C/C++/linker
+set(MIOSIX_CPU_FLAGS -mcpu=cortex-m4 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16)
+set(MIOSIX_A_FLAGS ${MIOSIX_CPU_FLAGS})
+list(APPEND MIOSIX_C_FLAGS
+    -D_ARCH_${MIOSIX_ARCH_NAME_UPPER} ${MIOSIX_HSE_VALUE} ${MIOSIX_SYSCLK_FREQ} ${XRAM}
+    ${SRAM_BOOT} ${MIOSIX_CPU_FLAGS} -c
+)
+list(APPEND MIOSIX_CXX_FLAGS
+    -D_ARCH_${MIOSIX_ARCH_NAME_UPPER} ${MIOSIX_HSE_VALUE} ${MIOSIX_SYSCLK_FREQ} ${XRAM}
+    ${SRAM_BOOT} ${MIOSIX_CPU_FLAGS} ${MIOSIX_OPT_EXCEPT} -c
+)
+set(MIOSIX_L_FLAGS
+    ${MIOSIX_CPU_FLAGS} -Wl,--gc-sections
+    -Wl,-T${MIOSIX_BOARD_INC}/${MIOSIX_LINKER_SCRIPT} ${MIOSIX_OPT_EXCEPT} -nostdlib
+)
+
+# Select architecture specific files
+list(APPEND MIOSIX_ARCH_SRC
+    ${MIOSIX_KPATH}/arch/common/sleep/cortexMx_sleep.cpp
+    ${MIOSIX_KPATH}/arch/common/drivers/stm32_serial_common.cpp
+    ${MIOSIX_KPATH}/arch/common/drivers/stm32f1_f2_f4_serial.cpp
+    ${MIOSIX_KPATH}/arch/common/drivers/dcc.cpp
+    ${MIOSIX_ARCH_INC}/interfaces-impl/delays.cpp
+    ${MIOSIX_KPATH}/arch/common/drivers/stm32_gpio.cpp
+    ${MIOSIX_KPATH}/arch/common/drivers/sd_stm32f2_f4_f7.cpp
+    ${MIOSIX_KPATH}/arch/common/os_timer/stm32_32bit_os_timer.cpp
+    ${MIOSIX_KPATH}/arch/common/CMSIS/Device/ST/STM32F4xx/Source/Templates/system_stm32f4xx.c
+)

--- a/miosix/arch/cortexM4_stm32f4/stm32f407vg_stm32f4discovery/CMakeLists.txt
+++ b/miosix/arch/cortexM4_stm32f4/stm32f407vg_stm32f4discovery/CMakeLists.txt
@@ -1,0 +1,99 @@
+# Copyright (C) 2024 by Skyward
+#
+# This program is free software; you can redistribute it and/or
+# it under the terms of the GNU General Public License as published
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# As a special exception, if other files instantiate templates or use
+# macros or inline functions from this file, or you compile this file
+# and link it with other works to produce a work based on this file,
+# this file does not by itself cause the resulting work to be covered
+# by the GNU General Public License. However the source code for this
+# file must still be made available in accordance with the GNU
+# Public License. This exception does not invalidate any other
+# why a work based on this file might be covered by the GNU General
+# Public License.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+
+# Directory with header files for this board
+set(MIOSIX_BOARD_INC ${MIOSIX_KPATH}/arch/${MIOSIX_ARCH_NAME}/${MIOSIX_OPT_BOARD})
+
+# The user can set a custom path for board_settings.h
+set(MIOSIX_CUSTOM_BOARD_SETTINGS_INC "" CACHE PATH "Include directory for custom board_settings.h")
+mark_as_advanced(MIOSIX_CUSTOM_BOARD_SETTINGS_INC)
+if(MIOSIX_CUSTOM_BOARD_SETTINGS_INC)
+    set(MIOSIX_BOARD_SETTINGS_INC ${MIOSIX_CUSTOM_BOARD_SETTINGS_INC})
+    message(NOTICE "You have set a custom path for board_settings.h")
+else()
+    set(MIOSIX_BOARD_SETTINGS_INC ${MIOSIX_KPATH}/config/arch/${MIOSIX_ARCH_NAME}/${MIOSIX_OPT_BOARD})
+endif()
+
+# Linker script options:
+# 1) Code in FLASH, stack + heap in internal RAM (file *_rom.ld)
+# 2) Code + stack + heap in internal RAM (file *_ram.ld)
+# 3) Same as 1) but space has been reserved for a process pool, allowing
+#    to configure the kernel with "#define WITH_PROCESSES"
+set(MIOSIX_LINKER_SCRIPT_LIST
+    stm32_1m+192k_rom.ld
+    stm32_1m+192k_ram.ld
+    stm32_1m+192k_rom_processes.ld
+)
+if(NOT MIOSIX_LINKER_SCRIPT IN_LIST MIOSIX_LINKER_SCRIPT_LIST)
+    # If there is no cached value, or the cached value is not in the list, set a default value
+    set(MIOSIX_LINKER_SCRIPT stm32_1m+192k_rom.ld CACHE STRING "Linker script" FORCE)
+endif()
+set_property(CACHE MIOSIX_LINKER_SCRIPT PROPERTY STRINGS ${MIOSIX_LINKER_SCRIPT_LIST})
+
+# This causes the interrupt vector table to be relocated in SRAM, must be
+# uncommented when using the ram linker script
+option(MIOSIX_SRAM_BOOT "This causes the interrupt vector table to be relocated in SRAM" OFF)
+if(MIOSIX_SRAM_BOOT)
+    set(SRAM_BOOT -DVECT_TAB_SRAM) # TODO: Change to an always defined flag
+elseif(MIOSIX_LINKER_SCRIPT STREQUAL ${MIOSIX_BOARD_INC}/stm32_1m+192k_ram.ld)
+    message(WARNING "You are relocating the interrupt vector table in SRAM but you are not using the ram linker script")
+endif()
+
+# Select HSE clock frequency (external clock on board, fixed)
+set(MIOSIX_HSE_VALUE -DHSE_VALUE=8000000)
+
+# Select clock frequency (HSE_VALUE is the xtal on board, fixed)
+set(MIOSIX_SYSCLK_FREQ_LIST
+    -DSYSCLK_FREQ_168MHz=168000000
+    -DSYSCLK_FREQ_100MHz=100000000
+    -DSYSCLK_FREQ_84MHz=84000000
+)
+if(NOT MIOSIX_SYSCLK_FREQ IN_LIST MIOSIX_SYSCLK_FREQ_LIST)
+    # If there is no cached value, or the cached value is not in the list, set a default value
+    set(MIOSIX_SYSCLK_FREQ -DSYSCLK_FREQ_168MHz=168000000 CACHE STRING "Clock frenquency" FORCE)
+endif()
+set_property(CACHE MIOSIX_SYSCLK_FREQ PROPERTY STRINGS ${MIOSIX_SYSCLK_FREQ_LIST})
+
+# Select architecture specific files
+set(MIOSIX_ARCH_SRC
+    ${MIOSIX_BOARD_INC}/boot.cpp
+    ${MIOSIX_KPATH}/arch/common/drivers/stm32f2_f4_i2c.cpp
+    ${MIOSIX_KPATH}/arch/common/drivers/stm32_hardware_rng.cpp
+    ${MIOSIX_KPATH}/arch/common/drivers/servo_stm32.cpp
+    ${MIOSIX_BOARD_INC}/drivers/rtc.cpp
+    ${MIOSIX_BOARD_INC}/interfaces-impl/sleep.cpp
+    ${MIOSIX_BOARD_INC}/interfaces-impl/bsp.cpp
+)
+
+# Add a #define to allow querying board name
+list(APPEND MIOSIX_C_FLAGS -D_BOARD_STM32F4DISCOVERY)
+list(APPEND MIOSIX_CXX_FLAGS -D_BOARD_STM32F4DISCOVERY)
+
+# Specify a custom flash command
+# This is the program that is invoked when the program-<target_name> target is
+# built. Use <binary> or <hex> as placeolders, they will be replaced by the
+# build systems with the binary or hex file path repectively.
+# If a command is not specified, the build system will fallback to st-flash
+# set(PROGRAM_CMDLINE st-flash --connect-under-reset --reset write <binary> 0x8000000)

--- a/miosix/arch/cortexM4_stm32f4/stm32f429zi_stm32f4discovery/CMakeLists.txt
+++ b/miosix/arch/cortexM4_stm32f4/stm32f429zi_stm32f4discovery/CMakeLists.txt
@@ -1,0 +1,107 @@
+# Copyright (C) 2024 by Skyward
+#
+# This program is free software; you can redistribute it and/or
+# it under the terms of the GNU General Public License as published
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# As a special exception, if other files instantiate templates or use
+# macros or inline functions from this file, or you compile this file
+# and link it with other works to produce a work based on this file,
+# this file does not by itself cause the resulting work to be covered
+# by the GNU General Public License. However the source code for this
+# file must still be made available in accordance with the GNU
+# Public License. This exception does not invalidate any other
+# why a work based on this file might be covered by the GNU General
+# Public License.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+
+# Directory with header files for this board
+set(MIOSIX_BOARD_INC ${MIOSIX_KPATH}/arch/${MIOSIX_ARCH_NAME}/${MIOSIX_OPT_BOARD})
+
+# The user can set a custom path for board_settings.h
+set(MIOSIX_CUSTOM_BOARD_SETTINGS_INC "" CACHE PATH "Include directory for custom board_settings.h")
+mark_as_advanced(MIOSIX_CUSTOM_BOARD_SETTINGS_INC)
+if(MIOSIX_CUSTOM_BOARD_SETTINGS_INC)
+    set(MIOSIX_BOARD_SETTINGS_INC ${MIOSIX_CUSTOM_BOARD_SETTINGS_INC})
+    message(NOTICE "You have set a custom path for board_settings.h")
+else()
+    set(MIOSIX_BOARD_SETTINGS_INC ${MIOSIX_KPATH}/config/arch/${MIOSIX_ARCH_NAME}/${MIOSIX_OPT_BOARD})
+endif()
+
+# Linker script type, there are three options
+# 1) Code in FLASH, stack + heap in internal RAM (file *_rom.ld)
+#    the most common choice, available for all microcontrollers
+# 2) Code in FLASH, stack + heap in external RAM (file *8m_xram.ld)
+#    You must uncomment -D__ENABLE_XRAM below in this case.
+# 3) Code in FLASH, stack + heap in external RAM (file *6m_xram.ld)
+#    Same as above, but leaves the upper 2MB of RAM for the LCD.
+set(MIOSIX_LINKER_SCRIPT_LIST
+    stm32_2m+256k_rom.ld
+    stm32_2m+256k_rom_processes.ld
+    stm32_2m+8m_xram.ld
+    stm32_2m+6m_xram.ld
+)
+if(NOT MIOSIX_LINKER_SCRIPT IN_LIST MIOSIX_LINKER_SCRIPT_LIST)
+    # If there is no cached value, or the cached value is not in the list, set a default value
+    set(MIOSIX_LINKER_SCRIPT stm32_2m+6m_xram.ld CACHE STRING "Linker script" FORCE)
+endif()
+set_property(CACHE MIOSIX_LINKER_SCRIPT PROPERTY STRINGS ${MIOSIX_LINKER_SCRIPT_LIST})
+
+# Uncommenting __ENABLE_XRAM enables the initialization of the external
+# 8MB SDRAM memory. Do not uncomment this even if you don't use a linker
+# script that requires it, as it is used for the LCD framebuffer.
+option(MIOSIX_ENABLE_XRAM "Enables the initialization of the external 16MB SDRAM memory" ON)
+if(MIOSIX_ENABLE_XRAM)
+    set(XRAM -D__ENABLE_XRAM) # TODO: Change to an always defined flag
+else()
+    message(NOTICE "You have disabled the XRAM, make sure that the selected linker script does not use it")
+endif()
+
+# Select HSE clock frequency (external clock on board, fixed)
+set(MIOSIX_HSE_VALUE -DHSE_VALUE=8000000)
+
+# Select clock frequency.
+# Warning: due to a limitation in the PLL, it is not possible to generate
+# a precise 48MHz output when running the core at 180MHz. If 180MHz is
+# chosen the SDIO and RNG will run ~6% slower (45MHz insteand of 48MHz)
+set(MIOSIX_SYSCLK_FREQ_LIST
+    -DSYSCLK_FREQ_180MHz=180000000
+    -DSYSCLK_FREQ_168MHz=168000000
+    -DSYSCLK_FREQ_100MHz=100000000
+)
+if(NOT MIOSIX_SYSCLK_FREQ IN_LIST MIOSIX_SYSCLK_FREQ_LIST)
+    # If there is no cached value, or the cached value is not in the list, set a default value
+    set(MIOSIX_SYSCLK_FREQ -DSYSCLK_FREQ_168MHz=168000000 CACHE STRING "Clock frenquency" FORCE)
+endif()
+set_property(CACHE MIOSIX_SYSCLK_FREQ PROPERTY STRINGS ${MIOSIX_SYSCLK_FREQ_LIST})
+
+if(MIOSIX_SYSCLK_FREQ STREQUAL -DSYSCLK_FREQ_180MHz=180000000)
+    message(NOTICE "The clock frequency has been set to 180MHz, the SDIO and RNG will run ~6% slower (45MHz insteand of 48MHz)")
+endif()
+
+# Select architecture specific files
+set(MIOSIX_ARCH_SRC
+    ${MIOSIX_BOARD_INC}/boot.cpp
+    ${MIOSIX_KPATH}/arch/common/drivers/stm32f2_f4_i2c.cpp
+    ${MIOSIX_KPATH}/arch/common/drivers/stm32_hardware_rng.cpp
+    ${MIOSIX_BOARD_INC}/interfaces-impl/bsp.cpp
+)
+
+# Add a #define to allow querying board name
+list(APPEND MIOSIX_C_FLAGS -D_BOARD_STM32F429ZI_STM32F4DISCOVERY)
+list(APPEND MIOSIX_CXX_FLAGS -D_BOARD_STM32F429ZI_STM32F4DISCOVERY)
+
+# Specify a custom flash command
+# This is the program that is invoked when the program-<target_name> target is
+# built. Use <binary> or <hex> as placeolders, they will be replaced by the
+# build systems with the binary or hex file path repectively.
+# If a command is not specified, the build system will fallback to st-flash
+# set(PROGRAM_CMDLINE st-flash --connect-under-reset --reset write <binary> 0x8000000)

--- a/miosix/arch/cortexM4_stm32f4/stm32f429zi_stm32f4discovery/stm32_2m+256k_rom_processes.ld
+++ b/miosix/arch/cortexM4_stm32f4/stm32f429zi_stm32f4discovery/stm32_2m+256k_rom_processes.ld
@@ -1,0 +1,183 @@
+/*
+ * C++ enabled linker script for stm32 (2M FLASH, 256K RAM)
+ * Developed by TFT: Terraneo Federico Technologies
+ * Optimized for use with the Miosix kernel
+ */
+
+/*
+ * This chip has an unusual quirk that the RAM is divided in two block mapped
+ * at two non contiguous memory addresses. I don't know why they've done that,
+ * probably doing the obvious thing would have made writing code too easy...
+ * Anyway, since hardware can't be changed, we've got to live with that and
+ * try to make use of both RAMs.
+ *
+ * Given the constraints above, this linker script puts:
+ * - read only data and code (.text, .rodata, .eh_*) in FLASH
+ * - the 512Byte main (IRQ) stack, .data and .bss in the "small" 64KB RAM
+ * - stacks and heap in the "large" 192KB RAM.
+ *
+ * Unfortunately thread stacks can't be put in the small RAM as Miosix
+ * allocates them inside the heap.
+ */
+
+/*
+ * The main stack is used for interrupt handling by the kernel.
+ *
+ * *** Readme ***
+ * This linker script places the main stack (used by the kernel for interrupts)
+ * at the bottom of the ram, instead of the top. This is done for two reasons:
+ *
+ * - as an optimization for microcontrollers with little ram memory. In fact
+ *   the implementation of malloc from newlib requests memory to the OS in 4KB
+ *   block (except the first block that can be smaller). This is probably done
+ *   for compatibility with OSes with an MMU and paged memory. To see why this
+ *   is bad, consider a microcontroller with 8KB of ram: when malloc finishes
+ *   up the first 4KB it will call _sbrk_r asking for a 4KB block, but this will
+ *   fail because the top part of the ram is used by the main stack. As a
+ *   result, the top part of the memory will not be used by malloc, even if
+ *   available (and it is nearly *half* the ram on an 8KB mcu). By placing the
+ *   main stack at the bottom of the ram, the upper 4KB block will be entirely
+ *   free and available as heap space.
+ *
+ * - In case of main stack overflow the cpu will fault because access to memory
+ *   before the beginning of the ram faults. Instead with the default stack
+ *   placement the main stack will silently collide with the heap.
+ * Note: if increasing the main stack size also increase the ORIGIN value in
+ * the MEMORY definitions below accordingly.
+ */
+_main_stack_size = 0x00000200;                     /* main stack = 512Bytes */
+_main_stack_top  = 0x10000000 + _main_stack_size;
+ASSERT(_main_stack_size   % 8 == 0, "MAIN stack size error");
+
+/* Mapping the heap into the bottom 32KB of the large 192KB RAM */
+_end =      0x20000000;
+_heap_end = 0x20008000;                            /* end of available ram  */
+/* Mapping the process pool into the upper 96KB of the large 128KB RAM */
+_process_pool_start = _heap_end;
+_process_pool_end = 0x20030000;                    /* end of available ram  */
+
+/* identify the Entry Point  */
+ENTRY(_ZN6miosix13Reset_HandlerEv)
+
+/* specify the memory areas  */
+MEMORY
+{
+    flash(rx)    : ORIGIN = 0x08000000, LENGTH =   2M
+    /*
+     * Note, the small ram starts at 0x10000000 but it is necessary to add the
+     * size of the main stack, so it is 0x10000200.
+     */
+    smallram(wx) : ORIGIN = 0x10000200, LENGTH =  64K-0x200
+    largeram(wx) : ORIGIN = 0x20000000, LENGTH = 192K
+}
+
+/* now define the output sections  */
+SECTIONS
+{
+    . = 0;
+
+    /* .text section: code goes to flash */
+    .text :
+    {
+        /* Startup code must go at address 0 */
+        KEEP(*(.isr_vector))
+
+        *(.text)
+        *(.text.*)
+        *(.gnu.linkonce.t.*)
+        /* these sections for thumb interwork? */
+        *(.glue_7)
+        *(.glue_7t)
+        /* these sections for C++? */
+        *(.gcc_except_table)
+        *(.gcc_except_table.*)
+        *(.ARM.extab*)
+        *(.gnu.linkonce.armextab.*)
+
+        . = ALIGN(4);
+        /* .rodata: constant data */
+        *(.rodata)
+        *(.rodata.*)
+        *(.gnu.linkonce.r.*)
+
+        /* C++ Static constructors/destructors (eabi) */
+        . = ALIGN(4);
+        KEEP(*(.init))
+
+        . = ALIGN(4);
+        __miosix_init_array_start = .;
+        KEEP (*(SORT(.miosix_init_array.*)))
+        KEEP (*(.miosix_init_array))
+        __miosix_init_array_end = .;
+
+        . = ALIGN(4);
+        __preinit_array_start = .;
+        KEEP (*(.preinit_array))
+        __preinit_array_end = .;
+
+        . = ALIGN(4);
+        __init_array_start = .;
+        KEEP (*(SORT(.init_array.*)))
+        KEEP (*(.init_array))
+        __init_array_end = .;
+
+        . = ALIGN(4);
+        KEEP(*(.fini))
+
+        . = ALIGN(4);
+        __fini_array_start = .;
+        KEEP (*(.fini_array))
+        KEEP (*(SORT(.fini_array.*)))
+        __fini_array_end = .;
+
+        /* C++ Static constructors/destructors (elf)  */
+        . = ALIGN(4);
+        _ctor_start = .;
+        KEEP (*crtbegin.o(.ctors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+        KEEP (*(SORT(.ctors.*)))
+        KEEP (*crtend.o(.ctors))
+       _ctor_end = .;
+
+        . = ALIGN(4);
+        KEEP (*crtbegin.o(.dtors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+        KEEP (*(SORT(.dtors.*)))
+        KEEP (*crtend.o(.dtors))
+    } > flash
+
+    /* .ARM.exidx is sorted, so has to go in its own output section.  */
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > flash
+    __exidx_end = .;
+
+	/* .data section: global variables go to ram, but also store a copy to
+       flash to initialize them */
+    .data : ALIGN(8)
+    {
+        _data = .;
+        *(.data)
+        *(.data.*)
+        *(.gnu.linkonce.d.*)
+        . = ALIGN(8);
+        _edata = .;
+    } > smallram AT > flash
+    _etext = LOADADDR(.data);
+
+    /* .bss section: uninitialized global variables go to ram */
+    _bss_start = .;
+    .bss :
+    {
+        *(.bss)
+        *(.bss.*)
+        *(.gnu.linkonce.b.*)
+        . = ALIGN(8);
+    } > smallram
+    _bss_end = .;
+
+    /*_end = .;*/
+    /*PROVIDE(end = .);*/
+}

--- a/miosix/arch/cortexM7_stm32f7/CMakeLists.txt
+++ b/miosix/arch/cortexM7_stm32f7/CMakeLists.txt
@@ -1,0 +1,65 @@
+# Copyright (C) 2024 by Skyward
+#
+# This program is free software; you can redistribute it and/or
+# it under the terms of the GNU General Public License as published
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# As a special exception, if other files instantiate templates or use
+# macros or inline functions from this file, or you compile this file
+# and link it with other works to produce a work based on this file,
+# this file does not by itself cause the resulting work to be covered
+# by the GNU General Public License. However the source code for this
+# file must still be made available in accordance with the GNU
+# Public License. This exception does not invalidate any other
+# why a work based on this file might be covered by the GNU General
+# Public License.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+
+# CPU microarchitecture
+set(MIOSIX_CPU_MICROARCH armv7m)
+
+# Base directory with common header files for this board
+set(MIOSIX_ARCH_INC ${MIOSIX_KPATH}/arch/${MIOSIX_ARCH_NAME}/common)
+
+# Include board specific options
+include(${MIOSIX_KPATH}/arch/${MIOSIX_ARCH_NAME}/${MIOSIX_OPT_BOARD}/CMakeLists.txt)
+
+# Automatically transform the architecture name into upper cases
+string(TOUPPER ${MIOSIX_ARCH_NAME} MIOSIX_ARCH_NAME_UPPER)
+
+# Select appropriate compiler flags for both C/C++/linker
+set(MIOSIX_A_FLAGS ${MIOSIX_CPU_FLAGS})
+list(APPEND MIOSIX_C_FLAGS
+    -D_ARCH_${MIOSIX_ARCH_NAME_UPPER} ${MIOSIX_HSE_VALUE} ${MIOSIX_SYSCLK_FREQ} ${XRAM}
+    ${SRAM_BOOT} ${MIOSIX_CPU_FLAGS} -c
+)
+list(APPEND MIOSIX_CXX_FLAGS
+    -D_ARCH_${MIOSIX_ARCH_NAME_UPPER} ${MIOSIX_HSE_VALUE} ${MIOSIX_SYSCLK_FREQ} ${XRAM}
+    ${SRAM_BOOT} ${MIOSIX_CPU_FLAGS} ${MIOSIX_OPT_EXCEPT} -c
+)
+set(MIOSIX_L_FLAGS
+    ${MIOSIX_CPU_FLAGS} -Wl,--gc-sections
+    -Wl,-T${MIOSIX_BOARD_INC}/${MIOSIX_LINKER_SCRIPT} ${MIOSIX_OPT_EXCEPT} -nostdlib
+)
+
+# Select architecture specific files
+list(APPEND MIOSIX_ARCH_SRC
+    ${MIOSIX_KPATH}/arch/common/sleep/cortexMx_sleep.cpp
+    ${MIOSIX_KPATH}/arch/common/cache/cortexMx_cache.cpp
+    ${MIOSIX_KPATH}/arch/common/drivers/stm32_serial_common.cpp
+    ${MIOSIX_KPATH}/arch/common/drivers/stm32f7_serial.cpp
+    ${MIOSIX_KPATH}/arch/common/drivers/sd_stm32f2_f4_f7.cpp
+    ${MIOSIX_KPATH}/arch/common/drivers/dcc.cpp
+    ${MIOSIX_ARCH_INC}/interfaces-impl/delays.cpp
+    ${MIOSIX_KPATH}/arch/common/drivers/stm32_gpio.cpp
+    ${MIOSIX_KPATH}/arch/common/os_timer/stm32_32bit_os_timer.cpp
+    ${MIOSIX_KPATH}/arch/common/CMSIS/Device/ST/STM32F7xx/Source/Templates/system_stm32f7xx.c
+)

--- a/miosix/arch/cortexM7_stm32f7/stm32f767zi_nucleo/CMakeLists.txt
+++ b/miosix/arch/cortexM7_stm32f7/stm32f767zi_nucleo/CMakeLists.txt
@@ -1,0 +1,104 @@
+# Copyright (C) 2024 by Skyward
+#
+# This program is free software; you can redistribute it and/or
+# it under the terms of the GNU General Public License as published
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# As a special exception, if other files instantiate templates or use
+# macros or inline functions from this file, or you compile this file
+# and link it with other works to produce a work based on this file,
+# this file does not by itself cause the resulting work to be covered
+# by the GNU General Public License. However the source code for this
+# file must still be made available in accordance with the GNU
+# Public License. This exception does not invalidate any other
+# why a work based on this file might be covered by the GNU General
+# Public License.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+
+# The stm32f767 has the double precision FPU, so we will build for m7
+set(MIOSIX_CPU_FLAGS -mcpu=cortex-m7 -mthumb -mfloat-abi=hard -mfpu=fpv5-d16)
+
+# Directory with header files for this board
+set(MIOSIX_BOARD_INC ${MIOSIX_KPATH}/arch/${MIOSIX_ARCH_NAME}/${MIOSIX_OPT_BOARD})
+
+# The user can set a custom path for board_settings.h
+set(MIOSIX_CUSTOM_BOARD_SETTINGS_INC "" CACHE PATH "Include directory for custom board_settings.h")
+mark_as_advanced(MIOSIX_CUSTOM_BOARD_SETTINGS_INC)
+if(MIOSIX_CUSTOM_BOARD_SETTINGS_INC)
+    set(MIOSIX_BOARD_SETTINGS_INC ${MIOSIX_CUSTOM_BOARD_SETTINGS_INC})
+    message(NOTICE "You have set a custom path for board_settings.h")
+else()
+    set(MIOSIX_BOARD_SETTINGS_INC ${MIOSIX_KPATH}/config/arch/${MIOSIX_ARCH_NAME}/${MIOSIX_OPT_BOARD})
+endif()
+
+# Linker script type, there are three options
+# 1) Code in FLASH, stack + heap in internal RAM (file *_rom.ld)
+#    the most common choice, available for all microcontrollers
+# 2) Code in FLASH, stack + heap in external RAM (file *8m_xram.ld)
+#    You must uncomment -D__ENABLE_XRAM below in this case.
+# 3) Code in FLASH, stack + heap in external RAM (file *6m_xram.ld)
+#    Same as above, but leaves the upper 2MB of RAM for the LCD.
+set(MIOSIX_LINKER_SCRIPT_LIST
+    stm32_2m+384k_ram.ld
+    stm32_2m+384k_ram_processes.ld
+)
+if(NOT MIOSIX_LINKER_SCRIPT IN_LIST MIOSIX_LINKER_SCRIPT_LIST)
+    # If there is no cached value, or the cached value is not in the list, set a default value
+    set(MIOSIX_LINKER_SCRIPT stm32_2m+384k_ram.ld CACHE STRING "Linker script" FORCE)
+endif()
+set_property(CACHE MIOSIX_LINKER_SCRIPT PROPERTY STRINGS ${MIOSIX_LINKER_SCRIPT_LIST})
+
+# Uncommenting __ENABLE_XRAM enables the initialization of the external
+# 8MB SDRAM memory. Do not uncomment this even if you don't use a linker
+# script that requires it, as it is used for the LCD framebuffer.
+option(MIOSIX_ENABLE_XRAM "Enables the initialization of the external 16MB SDRAM memory" ON)
+if(MIOSIX_ENABLE_XRAM)
+    set(XRAM -D__ENABLE_XRAM) # TODO: Change to an always defined flag
+else()
+    message(NOTICE "You have disabled the XRAM, make sure that the selected linker script does not use it")
+endif()
+
+# Select HSE clock frequency (external clock on board, fixed)
+set(MIOSIX_HSE_VALUE -DHSE_VALUE=8000000)
+
+# Select clock frequency.
+# Warning: due to a limitation in the PLL, it is not possible to generate
+# a precise 48MHz output when running the core at 180MHz. If 180MHz is
+# chosen the SDIO and RNG will run ~6% slower (45MHz insteand of 48MHz)
+set(MIOSIX_SYSCLK_FREQ_LIST
+    -DSYSCLK_FREQ_216MHz=216000000
+)
+if(NOT MIOSIX_SYSCLK_FREQ IN_LIST MIOSIX_SYSCLK_FREQ_LIST)
+    # If there is no cached value, or the cached value is not in the list, set a default value
+    set(MIOSIX_SYSCLK_FREQ -DSYSCLK_FREQ_216MHz=216000000 CACHE STRING "Clock frenquency" FORCE)
+endif()
+set_property(CACHE MIOSIX_SYSCLK_FREQ PROPERTY STRINGS ${MIOSIX_SYSCLK_FREQ_LIST})
+
+if(MIOSIX_SYSCLK_FREQ STREQUAL -DSYSCLK_FREQ_180MHz=180000000)
+    message(NOTICE "The clock frequency has been set to 180MHz, the SDIO and RNG will run ~6% slower (45MHz insteand of 48MHz)")
+endif()
+
+# Select architecture specific files
+set(MIOSIX_ARCH_SRC
+    ${MIOSIX_BOARD_INC}/boot.cpp
+    ${MIOSIX_BOARD_INC}/interfaces-impl/bsp.cpp
+)
+
+# Add a #define to allow querying board name
+list(APPEND MIOSIX_C_FLAGS -D_BOARD_STM32F767ZI_NUCLEO)
+list(APPEND MIOSIX_CXX_FLAGS -D_BOARD_STM32F767ZI_NUCLEO)
+
+# Specify a custom flash command
+# This is the program that is invoked when the program-<target_name> target is
+# built. Use <binary> or <hex> as placeolders, they will be replaced by the
+# build systems with the binary or hex file path repectively.
+# If a command is not specified, the build system will fallback to st-flash
+# set(PROGRAM_CMDLINE st-flash --connect-under-reset --reset write <binary> 0x8000000)

--- a/miosix/arch/cortexM7_stm32f7/stm32f767zi_nucleo/stm32_2m+384k_ram_processes.ld
+++ b/miosix/arch/cortexM7_stm32f7/stm32f767zi_nucleo/stm32_2m+384k_ram_processes.ld
@@ -1,0 +1,182 @@
+/*
+ * C++ enabled linker script for stm32f767zi (2M FLASH, 384K RAM)
+ * Developed by TFT: Terraneo Federico Technologies
+ * Optimized for use with the Miosix kernel
+ */
+
+/*
+ * This linker script puts:
+ * - read only data and code (.text, .rodata, .eh_*) in FLASH
+ * - the 512Byte main (IRQ) stack, .data and .bss in the DTCM 128KB RAM
+ * - .data, .bss, stacks and heap in the internal RAM.
+ */
+
+/*
+ * The main stack is used for interrupt handling by the kernel.
+ *
+ * *** Readme ***
+ * This linker script places the main stack (used by the kernel for interrupts)
+ * at the bottom of the ram, instead of the top. This is done for two reasons:
+ *
+ * - as an optimization for microcontrollers with little ram memory. In fact
+ *   the implementation of malloc from newlib requests memory to the OS in 4KB
+ *   block (except the first block that can be smaller). This is probably done
+ *   for compatibility with OSes with an MMU and paged memory. To see why this
+ *   is bad, consider a microcontroller with 8KB of ram: when malloc finishes
+ *   up the first 4KB it will call _sbrk_r asking for a 4KB block, but this will
+ *   fail because the top part of the ram is used by the main stack. As a
+ *   result, the top part of the memory will not be used by malloc, even if
+ *   available (and it is nearly *half* the ram on an 8KB mcu). By placing the
+ *   main stack at the bottom of the ram, the upper 4KB block will be entirely
+ *   free and available as heap space.
+ *
+ * - In case of main stack overflow the cpu will fault because access to memory
+ *   before the beginning of the ram faults. Instead with the default stack
+ *   placement the main stack will silently collide with the heap.
+ * Note: if increasing the main stack size also increase the ORIGIN value in
+ * the MEMORY definitions below accordingly.
+ */
+
+_main_stack_size = 512;                             /* main stack = 512Bytes */
+_main_stack_top  = 0x20000000 + _main_stack_size;
+ASSERT(_main_stack_size   % 8 == 0, "MAIN stack size error");
+
+/* Mapping the heap into the bottom 32KB of the large 384KB RAM */
+_end =      0x20020000;                            /* start of available ram */
+_heap_end = 0x20020000 + 32K;
+/* Mapping the process pool into the upper 352KB of the large 384KB RAM */
+_process_pool_start = _heap_end;
+_process_pool_end = 0x20020000 + 384K;             /* end of available ram  */
+
+/* Identify the Entry Point  */
+ENTRY(_ZN6miosix13Reset_HandlerEv)
+
+/*
+ * Specify the memory areas
+ *
+ * NOTE: starting at 0x20000000 there's 128KB of DTCM (Data Tightly Coupled
+ * Memory). Technically, we could use this as normal RAM as there's a way for
+ * the DMA to access it, but the datasheet is unclear about performance
+ * penalties for doing so. To avoid nonuniform DMA memory access latencies,
+ * we leave this 128KB DTCM unused except for the first 512Bytes which are for
+ * the interrupt stack. This leaves us with 384KB of RAM
+ */
+MEMORY
+{
+    sram(wx)  : ORIGIN = 0x20020000, LENGTH = 384K
+    dtcm(wx)  : ORIGIN = 0x20000000, LENGTH = 128K    /* Used for main stack */
+    flash(rx) : ORIGIN = 0x08000000, LENGTH =   2M
+}
+
+/* now define the output sections  */
+SECTIONS
+{
+    . = 0;
+
+    /* .text section: code goes to flash */
+    .text :
+    {
+        /* Startup code must go at address 0 */
+        KEEP(*(.isr_vector))
+
+        *(.text)
+        *(.text.*)
+        *(.gnu.linkonce.t.*)
+        /* these sections for thumb interwork? */
+        *(.glue_7)
+        *(.glue_7t)
+        /* these sections for C++? */
+        *(.gcc_except_table)
+        *(.gcc_except_table.*)
+        *(.ARM.extab*)
+        *(.gnu.linkonce.armextab.*)
+
+        . = ALIGN(4);
+        /* .rodata: constant data */
+        *(.rodata)
+        *(.rodata.*)
+        *(.gnu.linkonce.r.*)
+
+        /* C++ Static constructors/destructors (eabi) */
+        . = ALIGN(4);
+        KEEP(*(.init))
+
+        . = ALIGN(4);
+        __miosix_init_array_start = .;
+        KEEP (*(SORT(.miosix_init_array.*)))
+        KEEP (*(.miosix_init_array))
+        __miosix_init_array_end = .;
+
+        . = ALIGN(4);
+        __preinit_array_start = .;
+        KEEP (*(.preinit_array))
+        __preinit_array_end = .;
+
+        . = ALIGN(4);
+        __init_array_start = .;
+        KEEP (*(SORT(.init_array.*)))
+        KEEP (*(.init_array))
+        __init_array_end = .;
+
+        . = ALIGN(4);
+        KEEP(*(.fini))
+
+        . = ALIGN(4);
+        __fini_array_start = .;
+        KEEP (*(.fini_array))
+        KEEP (*(SORT(.fini_array.*)))
+        __fini_array_end = .;
+
+        /* C++ Static constructors/destructors (elf)  */
+        . = ALIGN(4);
+        _ctor_start = .;
+        KEEP (*crtbegin.o(.ctors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+        KEEP (*(SORT(.ctors.*)))
+        KEEP (*crtend.o(.ctors))
+       _ctor_end = .;
+
+        . = ALIGN(4);
+        KEEP (*crtbegin.o(.dtors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+        KEEP (*(SORT(.dtors.*)))
+        KEEP (*crtend.o(.dtors))
+    } > flash
+
+    /* .ARM.exidx is sorted, so has to go in its own output section.  */
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > flash
+    __exidx_end = .;
+
+	/*
+     * .data section: global variables go to sram, but also store a copy to
+     * flash to initialize them
+     */
+    .data : ALIGN(8)
+    {
+        _data = .;
+        *(.data)
+        *(.data.*)
+        *(.gnu.linkonce.d.*)
+        . = ALIGN(8);
+        _edata = .;
+    } > sram AT > flash
+    _etext = LOADADDR(.data);
+
+    /* .bss section: uninitialized global variables go to sram */
+    _bss_start = .;
+    .bss :
+    {
+        *(.bss)
+        *(.bss.*)
+        *(.gnu.linkonce.b.*)
+        . = ALIGN(8);
+    } > sram
+    _bss_end = .;
+
+    _end = .;
+    PROVIDE(end = .);
+}

--- a/miosix/arch/cpu/CMakeLists.txt
+++ b/miosix/arch/cpu/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright (C) 2024 by Skyward
+#
+# This program is free software; you can redistribute it and/or
+# it under the terms of the GNU General Public License as published
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# As a special exception, if other files instantiate templates or use
+# macros or inline functions from this file, or you compile this file
+# and link it with other works to produce a work based on this file,
+# this file does not by itself cause the resulting work to be covered
+# by the GNU General Public License. However the source code for this
+# file must still be made available in accordance with the GNU
+# Public License. This exception does not invalidate any other
+# why a work based on this file might be covered by the GNU General
+# Public License.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+
+# Set CPU microarchitecture specific include paths
+list(APPEND MIOSIX_ARCH_INC ${MIOSIX_KPATH}/arch/cpu)
+
+# Add CPU common sources
+list(APPEND MIOSIX_ARCH_SRC
+    ${MIOSIX_KPATH}/arch/cpu/common/cortexMx_interrupts.cpp
+    ${MIOSIX_KPATH}/arch/cpu/common/cortexMx_userspace.cpp
+)
+
+# Include CPU microarchitecture dependencies
+include(${MIOSIX_KPATH}/arch/cpu/${MIOSIX_CPU_MICROARCH}/CMakeLists.txt)

--- a/miosix/arch/cpu/armv7m/CMakeLists.txt
+++ b/miosix/arch/cpu/armv7m/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright (C) 2024 by Skyward
+#
+# This program is free software; you can redistribute it and/or
+# it under the terms of the GNU General Public License as published
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# As a special exception, if other files instantiate templates or use
+# macros or inline functions from this file, or you compile this file
+# and link it with other works to produce a work based on this file,
+# this file does not by itself cause the resulting work to be covered
+# by the GNU General Public License. However the source code for this
+# file must still be made available in accordance with the GNU
+# Public License. This exception does not invalidate any other
+# why a work based on this file might be covered by the GNU General
+# Public License.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+
+# Set CPU microarchitecture specific include paths
+list(APPEND MIOSIX_ARCH_INC ${MIOSIX_KPATH}/arch/cpu/${MIOSIX_CPU_MICROARCH})
+
+# Select architecture specific files
+list(APPEND MIOSIX_ARCH_SRC
+    ${MIOSIX_KPATH}/arch/cpu/${MIOSIX_CPU_MICROARCH}/interfaces-impl/cpu.cpp
+)

--- a/miosix/cmake/AddProcess.cmake
+++ b/miosix/cmake/AddProcess.cmake
@@ -1,0 +1,62 @@
+# Copyright (C) 2024 by Skyward
+#
+# This program is free software; you can redistribute it and/or
+# it under the terms of the GNU General Public License as published
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# As a special exception, if other files instantiate templates or use
+# macros or inline functions from this file, or you compile this file
+# and link it with other works to produce a work based on this file,
+# this file does not by itself cause the resulting work to be covered
+# by the GNU General Public License. However the source code for this
+# file must still be made available in accordance with the GNU
+# Public License. This exception does not invalidate any other
+# why a work based on this file might be covered by the GNU General
+# Public License.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+
+# Function to create a Miosix process
+#
+#   miosix_add_process(<target> <source1> <source2> ...)
+#
+# What is does:
+# - Create an executable target with the given sources
+# - Link the libraries required by processes
+# - Tell the linker to produce a map file
+# - Run strip and mx-postlinker on the executable
+function(miosix_add_process TARGET SOURCES)
+    # Define the executable with its sources
+    add_executable(${TARGET} ${SOURCES})
+
+    # Link syscalls and other libraries
+    target_link_libraries(${TARGET} PRIVATE
+        -Wl,--start-group syscalls stdc++ c m gcc atomic -Wl,--end-group
+    )
+
+    # Tell the linker to produce the map file
+    target_link_options(${TARGET} PRIVATE -Wl,-Map,$<TARGET_FILE_DIR:${TARGET}>/$<TARGET_FILE_BASE_NAME:${TARGET}>.map)
+
+    # Strin unnecessary sections from the ELF
+    add_custom_command(
+        TARGET ${TARGET} POST_BUILD
+        COMMAND arm-miosix-eabi-strip $<TARGET_FILE:${TARGET}>
+        COMMENT "Stripping $<TARGET_FILE_NAME:${TARGET}>"
+    )
+
+    # Run mx-postlinker to strip the section header, string table and
+    # setting Miosix specic options in the dynamic segnment
+    add_custom_command(
+        TARGET ${TARGET} POST_BUILD
+        COMMAND mx-postlinker $<TARGET_FILE:${TARGET}> --ramsize=16384 --stacksize=2048 --strip-sectheader
+        # BYPRODUCTS $<TARGET_FILE:${TARGET}>
+        COMMENT "Running mx-postlinker on $<TARGET_FILE_NAME:${TARGET}>"
+    )
+endfunction()

--- a/miosix/cmake/AddProgramTarget.cmake
+++ b/miosix/cmake/AddProgramTarget.cmake
@@ -1,0 +1,56 @@
+# Copyright (C) 2024 by Skyward
+#
+# This program is free software; you can redistribute it and/or
+# it under the terms of the GNU General Public License as published
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# As a special exception, if other files instantiate templates or use
+# macros or inline functions from this file, or you compile this file
+# and link it with other works to produce a work based on this file,
+# this file does not by itself cause the resulting work to be covered
+# by the GNU General Public License. However the source code for this
+# file must still be made available in accordance with the GNU
+# Public License. This exception does not invalidate any other
+# why a work based on this file might be covered by the GNU General
+# Public License.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+
+# Creates a custom target to program the board (${TARGET}_program))
+#
+#   miosix_add_program_target(<target> [DEPENDS <target1> <target2> ...])
+function(miosix_add_program_target TARGET)
+    cmake_parse_arguments(PROGRAM "" "" "DEPENDS" ${ARGN})
+
+    if(NOT PROGRAM_DEPENDS)
+        add_custom_command(
+            OUTPUT ${TARGET}.bin
+            COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:${TARGET}> ${TARGET}.bin
+            DEPENDS ${TARGET}
+            COMMENT "Creating ${TARGET}.bin"
+            VERBATIM
+        )
+        add_custom_target(${TARGET}_bin ALL DEPENDS ${TARGET}.bin)
+        set(PROGRAM_DEPENDS ${TARGET}_bin)
+    endif()
+
+    get_target_property(PROGRAM_CMDLINE miosix PROGRAM_CMDLINE)
+    if(PROGRAM_CMDLINE STREQUAL "PROGRAM_CMDLINE-NOTFOUND")
+        set(PROGRAM_CMDLINE st-flash --connect-under-reset --reset write <binary> 0x8000000)
+    endif()
+
+    list(TRANSFORM PROGRAM_CMDLINE REPLACE <binary> ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}.bin)
+    list(TRANSFORM PROGRAM_CMDLINE REPLACE <hex> ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}.hex)
+
+    add_custom_target(${TARGET}_program ${PROGRAM_CMDLINE}
+        DEPENDS ${PROGRAM_DEPENDS}
+        VERBATIM
+    )
+endfunction()

--- a/miosix/cmake/AddRomfsImage.cmake
+++ b/miosix/cmake/AddRomfsImage.cmake
@@ -1,0 +1,92 @@
+# Copyright (C) 2024 by Skyward
+#
+# This program is free software; you can redistribute it and/or
+# it under the terms of the GNU General Public License as published
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# As a special exception, if other files instantiate templates or use
+# macros or inline functions from this file, or you compile this file
+# and link it with other works to produce a work based on this file,
+# this file does not by itself cause the resulting work to be covered
+# by the GNU General Public License. However the source code for this
+# file must still be made available in accordance with the GNU
+# Public License. This exception does not invalidate any other
+# why a work based on this file might be covered by the GNU General
+# Public License.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+
+include(ExternalProject)
+include(AddProgramTarget)
+include(CreateProcessesDir)
+
+# Create a target that builds the buildromfs tool
+ExternalProject_Add(buildromfs
+    SOURCE_DIR ${MIOSIX_KPATH}/_tools/filesystems
+    INSTALL_COMMAND "" # Skip install
+)
+
+# Create a target that builds the romfs image and combines it the kernel into a single binary image
+#
+#   miosix_add_romfs_image(
+#     IMAGE_NAME <name>
+#     KERNEL <kernel>
+#     DIR_NAME <dir_name>
+#     PROCESSES <process1> <process2> ...
+#   )
+#
+# What it does:
+# - Copies all processes binaries to a single directory named <dir_name>
+# - Creates a romfs image with of the directory <dir_name>
+# - Combines the kernel and the romfs image into a single binary image
+# - Registers a custom target (named <dir_name>) with to run the above steps
+function(miosix_add_romfs_image)
+    cmake_parse_arguments(ROMFS "" "IMAGE_NAME;KERNEL;DIR_NAME" "PROCESSES" ${ARGN})
+
+    # If the user did not provide a directory name, use "bin" as default
+    if(NOT ROMFS_DIR_NAME)
+        set(ROMFS_DIR_NAME bin)
+        message(NOTICE "You did not provide a directory name for romfs, using ${ROMFS_DIR_NAME} as default")
+    endif()
+
+    # Copy all processes binaries to a single directory
+    miosix_create_processes_dir(
+        DIR_NAME ${ROMFS_DIR_NAME}
+        PROCESSES ${ROMFS_PROCESSES}
+    )
+
+    # Create the image of the kernel
+    add_custom_command(
+        OUTPUT ${ROMFS_KERNEL}.bin
+        DEPENDS ${ROMFS_KERNEL}
+        COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:${ROMFS_KERNEL}> ${ROMFS_KERNEL}.bin
+        COMMENT "Creating ${ROMFS_KERNEL}.bin"
+        VERBATIM
+    )
+
+    # Create the romfs image with the given processes
+    add_custom_command(
+        OUTPUT ${ROMFS_IMAGE_NAME}-romfs.bin
+        DEPENDS ${MIOSIX_${ROMFS_DIR_NAME}_FILES} buildromfs
+        COMMAND ${MIOSIX_KPATH}/_tools/filesystems/buildromfs ${ROMFS_IMAGE_NAME}-romfs.bin --from-directory ${ROMFS_DIR_NAME}
+        COMMENT "Building ${ROMFS_IMAGE_NAME}-romfs.bin"
+    )
+
+    # Combin kernel and romfs images
+    add_custom_command(
+        OUTPUT ${ROMFS_IMAGE_NAME}.bin
+        DEPENDS ${ROMFS_KERNEL}.bin ${ROMFS_IMAGE_NAME}-romfs.bin
+        COMMAND perl ${MIOSIX_KPATH}/_tools/filesystems/mkimage.pl ${ROMFS_IMAGE_NAME}.bin ${ROMFS_KERNEL}.bin ${ROMFS_IMAGE_NAME}-romfs.bin
+        COMMENT "Combining ${ROMFS_KERNEL}.bin and ${ROMFS_IMAGE_NAME}-romfs.bin into ${ROMFS_IMAGE_NAME}.bin"
+    )
+
+    # Create the custom romfs target
+    add_custom_target(${ROMFS_IMAGE_NAME} ALL DEPENDS ${PROJECT_BINARY_DIR}/${ROMFS_IMAGE_NAME}.bin)
+endfunction()

--- a/miosix/cmake/CreateProcessesDir.cmake
+++ b/miosix/cmake/CreateProcessesDir.cmake
@@ -1,0 +1,52 @@
+# Copyright (C) 2024 by Skyward
+#
+# This program is free software; you can redistribute it and/or
+# it under the terms of the GNU General Public License as published
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# As a special exception, if other files instantiate templates or use
+# macros or inline functions from this file, or you compile this file
+# and link it with other works to produce a work based on this file,
+# this file does not by itself cause the resulting work to be covered
+# by the GNU General Public License. However the source code for this
+# file must still be made available in accordance with the GNU
+# Public License. This exception does not invalidate any other
+# why a work based on this file might be covered by the GNU General
+# Public License.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+
+# Copies processes binaries into a single directory
+#
+#   miosix_create_processes_dir(
+#     DIR_NAME <dir_name>
+#     PROCESSES <process1> <process2> ...
+#   )
+#
+# This function addresses two use cases:
+# - When you need to build a romfs image, you need all processes into a single directory
+# - If you want to load processes on to an SD card for example, is useful to have all processes grouped togheter
+function(miosix_create_processes_dir)
+    cmake_parse_arguments(PROCS "" "DIR_NAME" "PROCESSES" ${ARGN})
+
+    # Copy all processes binaries to a single directory
+    foreach(ROMFS_PROCESS ${ROMFS_PROCESSES})
+        add_custom_command(
+            OUTPUT ${PROJECT_BINARY_DIR}/${ROMFS_DIR_NAME}/${ROMFS_PROCESS}
+            DEPENDS ${ROMFS_PROCESS}
+            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${ROMFS_PROCESS}> ${PROJECT_BINARY_DIR}/${ROMFS_DIR_NAME}/${ROMFS_PROCESS}
+            COMMENT "Copying process $<TARGET_FILE_BASE_NAME:${ROMFS_PROCESS}> into ${ROMFS_DIR_NAME} directory"
+        )
+        list(APPEND MIOSIX_${PROCS_DIR_NAME}_FILES ${PROJECT_BINARY_DIR}/${ROMFS_DIR_NAME}/${ROMFS_PROCESS})
+    endforeach()
+
+    # Move the list variable in the parent scope
+    set(MIOSIX_${PROCS_DIR_NAME}_FILES ${MIOSIX_${PROCS_DIR_NAME}_FILES} PARENT_SCOPE)
+endfunction()

--- a/miosix/cmake/LinkTarget.cmake
+++ b/miosix/cmake/LinkTarget.cmake
@@ -1,0 +1,49 @@
+# Copyright (C) 2024 by Skyward
+#
+# This program is free software; you can redistribute it and/or
+# it under the terms of the GNU General Public License as published
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# As a special exception, if other files instantiate templates or use
+# macros or inline functions from this file, or you compile this file
+# and link it with other works to produce a work based on this file,
+# this file does not by itself cause the resulting work to be covered
+# by the GNU General Public License. However the source code for this
+# file must still be made available in accordance with the GNU
+# Public License. This exception does not invalidate any other
+# why a work based on this file might be covered by the GNU General
+# Public License.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+
+include(AddProgramTarget)
+
+# Function to link the Miosix libraries to a target and register the build command
+#
+#   miosix_link_target(<target>)
+#
+# What it does:
+# - Links the Miosix libraries to the target
+# - Tells the linker to generate the map file
+function(miosix_link_target TARGET)
+    if (NOT TARGET miosix)
+        message(FATAL_ERROR "The board you selected is not supported")
+    endif()
+
+    # Linker script and linking options are eredited from miosix libraries
+
+    # Link libraries
+    target_link_libraries(${TARGET} PUBLIC
+        -Wl,--start-group miosix stdc++ c m gcc atomic -Wl,--end-group
+    )
+
+    # Tell the linker to produce the map file
+    target_link_options(${TARGET} PRIVATE -Wl,-Map,$<TARGET_FILE_DIR:${TARGET}>/$<TARGET_FILE_BASE_NAME:${TARGET}>.map)
+endfunction()

--- a/miosix/cmake/Platform/Miosix.cmake
+++ b/miosix/cmake/Platform/Miosix.cmake
@@ -1,0 +1,34 @@
+# Copyright (C) 2024 by Skyward
+#
+# This program is free software; you can redistribute it and/or 
+# it under the terms of the GNU General Public License as published 
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# As a special exception, if other files instantiate templates or use
+# macros or inline functions from this file, or you compile this file
+# and link it with other works to produce a work based on this file,
+# this file does not by itself cause the resulting work to be covered
+# by the GNU General Public License. However the source code for this
+# file must still be made available in accordance with the GNU 
+# Public License. This exception does not invalidate any other 
+# why a work based on this file might be covered by the GNU General
+# Public License.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+
+# Miosix does not support shared libraries
+set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS FALSE)
+
+# File extensions
+set(CMAKE_ASM_OUTPUT_EXTENSION .o)
+set(CMAKE_C_OUTPUT_EXTENSION .o)
+set(CMAKE_CXX_OUTPUT_EXTENSION .o)
+set(CMAKE_STATIC_LIBRARY_SUFFIX .a)
+set(CMAKE_EXECUTABLE_SUFFIX .elf)

--- a/miosix/cmake/Toolchains/gcc.cmake
+++ b/miosix/cmake/Toolchains/gcc.cmake
@@ -1,0 +1,58 @@
+# Copyright (C) 2024 by Skyward
+#
+# This program is free software; you can redistribute it and/or
+# it under the terms of the GNU General Public License as published
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# As a special exception, if other files instantiate templates or use
+# macros or inline functions from this file, or you compile this file
+# and link it with other works to produce a work based on this file,
+# this file does not by itself cause the resulting work to be covered
+# by the GNU General Public License. However the source code for this
+# file must still be made available in accordance with the GNU
+# Public License. This exception does not invalidate any other
+# why a work based on this file might be covered by the GNU General
+# Public License.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+
+# Add the miosix/cmake path to find the Miosix.cmake platform file
+# that defines the Miosix system name
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/..)
+
+# Tell CMake that we are building for an embedded ARM system
+set(CMAKE_SYSTEM_NAME Miosix)
+
+# Select compiler
+set(MIOSIX_PREFIX      arm-miosix-eabi)
+
+# From compiler prefix form the name of the compiler and other tools
+set(CMAKE_ASM_COMPILER ${MIOSIX_PREFIX}-as)
+set(CMAKE_C_COMPILER   ${MIOSIX_PREFIX}-gcc)
+set(CMAKE_CXX_COMPILER ${MIOSIX_PREFIX}-g++)
+set(CMAKE_AR           ${MIOSIX_PREFIX}-ar)
+set(CMAKE_OBJCOPY      ${MIOSIX_PREFIX}-objcopy)
+set(CMAKE_OBJDUMP      ${MIOSIX_PREFIX}-objdump)
+set(CMAKE_SIZE         ${MIOSIX_PREFIX}-size)
+set(MIOSIX_READELF     ${MIOSIX_PREFIX}-readelf)
+
+# Optimization flags for each language and build configuration
+set(CMAKE_ASM_FLAGS_DEBUG "")
+set(CMAKE_C_FLAGS_DEBUG "-g -O0")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
+set(CMAKE_ASM_FLAGS_RELEASE "")
+set(CMAKE_C_FLAGS_RELEASE "-O2")
+set(CMAKE_CXX_FLAGS_RELEASE "-O2")
+set(CMAKE_ASM_FLAGS_RELWITHDEBINFO "")
+set(CMAKE_C_FLAGS_RELWITHDEBINFO "-g -O2")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g -O2")
+set(CMAKE_ASM_FLAGS_MINSIZEREL "")
+set(CMAKE_C_FLAGS_MINSIZEREL "-Os")
+set(CMAKE_CXX_FLAGS_MINSIZEREL "-Os")

--- a/miosix/default/config/miosix_settings.h
+++ b/miosix/default/config/miosix_settings.h
@@ -29,7 +29,9 @@
 
 // Before you can compile the kernel you have to configure it by editing this
 // file. After that, comment out this line to disable the reminder error.
+#ifndef MIOSIX_SKIP_SETTINGS_EDIT
 #error This error is a reminder that you have not edited miosix_settings.h yet.
+#endif
 
 /**
  * \file miosix_settings.h

--- a/miosix/libsyscalls/CMakeLists.txt
+++ b/miosix/libsyscalls/CMakeLists.txt
@@ -1,0 +1,81 @@
+# Copyright (C) 2024 by Skyward
+#
+# This program is free software; you can redistribute it and/or
+# it under the terms of the GNU General Public License as published
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# As a special exception, if other files instantiate templates or use
+# macros or inline functions from this file, or you compile this file
+# and link it with other works to produce a work based on this file,
+# this file does not by itself cause the resulting work to be covered
+# by the GNU General Public License. However the source code for this
+# file must still be made available in accordance with the GNU
+# Public License. This exception does not invalidate any other
+# why a work based on this file might be covered by the GNU General
+# Public License.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+
+cmake_minimum_required(VERSION 3.16)
+
+project(LibSyscalls C CXX ASM)
+
+# syscalls is the library with userspace syscalls for processes
+
+# Include the architecture options, we need the variables listed below
+include(${MIOSIX_KPATH}/arch/CMakeLists.txt)
+
+# Verify that all the required variables have been defined, otherwise abort
+set(REQUIRED_VARIABLES
+    MIOSIX_ARCH_INC
+    MIOSIX_BOARD_INC
+    MIOSIX_BOARD_SETTINGS_INC
+    MIOSIX_CPU_FLAGS
+)
+foreach(VARIABLE ${REQUIRED_VARIABLES})
+    if(NOT DEFINED ${VARIABLE})
+        message(FATAL_ERROR "arch/CMakeLists.txt must define ${VARIABLE}")
+    endif()
+endforeach()
+
+# Define the syscalls library
+add_library(syscalls STATIC crt0.s crt1.cpp memoryprofiling.cpp)
+
+target_include_directories(syscalls PUBLIC
+    ${MIOSIX_KPATH}
+    ${MIOSIX_KPATH}/arch/common
+    ${MIOSIX_ARCH_INC}
+    ${MIOSIX_BOARD_INC}
+    ${MIOSIX_BOARD_SETTINGS_INC}
+    ${MIOSIX_SETTINGS_PATH}
+)
+
+# ASM/C/C++ flags for processes
+# The important flags are the CPU ones, -fpie and -msingle-pic-base
+set(MIOSIX_PROCESSES_A_FLAGS ${MIOSIX_CPU_FLAGS})
+set(MIOSIX_PROCESSES_C_FLAGS
+    ${MIOSIX_CPU_FLAGS} -fpie -msingle-pic-base -ffunction-sections -Wall
+    -Werror=return-type -D_DEFAULT_SOURCE=1 -c
+)
+set(MIOSIX_PROCESSES_CXX_FLAGS -std=c++14 ${MIOSIX_OPT_EXCEPT} ${MIOSIX_PROCESSES_C_FLAGS})
+target_compile_options(syscalls PUBLIC
+    $<$<COMPILE_LANGUAGE:ASM>:${MIOSIX_PROCESSES_A_FLAGS}>
+    $<$<COMPILE_LANGUAGE:C>:${MIOSIX_PROCESSES_C_FLAGS}>
+    $<$<COMPILE_LANGUAGE:CXX>:${MIOSIX_PROCESSES_CXX_FLAGS}>
+)
+
+# Configure linker file and options needed to link agains this library
+set(MIOSIX_PROCESSES_L_FLAGS
+    ${MIOSIX_CPU_FLAGS} -fpie -msingle-pic-base -nostdlib -Wl,--gc-sections
+    -Wl,-T${MIOSIX_KPATH}/libsyscalls/process.ld
+    -Wl,-n,-pie,--spare-dynamic-tags,3,--target2=mx-data-rel
+)
+set_property(TARGET syscalls PROPERTY LINK_DEPENDS ${MIOSIX_KPATH}/libsyscalls/process.ld)
+target_link_options(syscalls INTERFACE ${MIOSIX_PROCESSES_L_FLAGS})


### PR DESCRIPTION
# Miosix CMake support

## A brief history

Support for CMake was first proposed in #3 by @mscuttari (2019), then further developed by @damianoamatruda at Skyward (2022), and now finalized to be merged into the kernel.

Skyward's use case is very specific because in their two main repos they maintain a lot of executables targetting many different boards (in [Boardcore](https://git.skywarder.eu/avn/swd/skyward-boardcore) there is a test executable for each sensor's driver and in [On-Board Software](https://git.skywarder.eu/avn/swd/obsw) there is an executable for each board on the rocket). For this reason, they basically created a CMake library for each board in order to define multiple executables targeting different boards in a single `CMakeFile.txt`.

Although the structure used by Skyward has worked well, to officially introduce CMake into the kernel we would like to follow as closely as possible the current Make based system. For this reason, Skyward's CMake was improved upon and now resembles much more a standard CMake based project.

## Quick start

Move to your executable's directory. We'll take `miosix/_examples/blinking_led` as an example.

Build your code with:

```bash
cmake -Bbuild -DCMAKE_TOOLCHAIN_FILE=../../cmake/Toolchains/gcc.cmake
cmake --build build --target blinking_led
```

And flash the binary on you board with:

```bash
cmake --build build --target blinking_led_program
```

## In depth description

The proposed CMake base build system was developed targeting these features:
- Follow the current Make based build system structure
- Provide a modern and standard build system based on CMake
- Simplify project configuration for first time users by hiding Miosix specific configuration steps
- Build system level support for flashing binaries, like `make program`
- Possibility to use a custom `miosix_settings.h` outside of kernel director
- Possibility to support new boards outside of the kernel directory

The build system is contained in the `miosix` folder and composed of:
- `CMakeLists.txt`: Includes specific architecture/board files, defines common kernel source files, include directories and flags, and runs the `kernel_global_objects.pl` script.
- `arch/CMakeLists.txt`: Contains the list of supported boards, include the selected board's files.
- `arch/<family>/CMakeLists.txt`: Sets flags (e.g. `-mcpu`, `-mfpu`, ...) and source files common to all chips in the family.
- `arch/<family>/<board>/CMakeLists.txt`: Configures chip/board specific things like the linker script and clock frequency.

To simplify CMake files, common functionalities were moved into function which can be found in `miosix/cmake`. In particular `miosix_link_target(TARGET)` links a CMake target against the kernel, automatically configuring link libraries, binary file creation and the `<TARGET>_program` target which can be used to flash the board.

For the user to link with the kernel, a few lines of CMake are necessary:

```CMake
set(MIOSIX_OPT_BOARD stm32f429zi_stm32f4discovery CACHE STRING "Target board")
add_subdirectory(../.. miosix EXCLUDE_FROM_ALL)
include(LinkTarget)

add_executable(blinking_led simple.cpp)
miosix_link_target(blinking_led)
```

### Processes

Support for easily create processes was also added, along with a simple example (`miosix/_examples/processes`).

The idea boils down to create the usual target for your kernel, one target for each process and then a target to build the combined RomFS image.

```CMake
# Kernel level program
add_executable(main main.cpp)
miosix_link_target(main)

# Processes
miosix_add_process(process1 process1.cpp)
miosix_add_process(process2 process2.cpp)

# RomFS image
miosix_add_romfs_image(
    IMAGE_NAME image
    DIR_NAME bin
    KERNEL main
    PROCESSES process1 process2
)
```

This will define two additional targets: `image` to build the RomFS image, and  `image_program` to flash the binary on the board.

## Simple tutorial

After cloning Miosix you will find many examples in the `miosix/_examples` folder. We'll take `blinking_led` as an example.

The `CMakeFile.txt` very simple, here a quick overview:

```CMake
cmake_minimum_required(VERSION 3.16)
project(BlinkingLED C CXX ASM)
```

These are common to any CMake project. They specify the minimum required version of CMake (3.16 is shipped with Ubuntu 20.04, so you should be fine) and define a new project called "BlinkingLED".

```CMake
add_compile_definitions($<$<COMPILE_LANGUAGE:C,CXX>:PARSING_FROM_IDE>)
```

This tells the compiler to define `PARSING_FROM_IDE` so that the check in `miosix_settings.h` gets bypassed.

```CMake
set(MIOSIX_OPT_BOARD stm32f429zi_stm32f4discovery CACHE STRING "Target board")
```

This tells the build system which board you are using. You can find all the supported boards in the `miosix/arch` folders or by defining the `MIOSIX_PRINT_BOARD_LIST` option (e.g. by running `cmake -Bbuild -DMIOSIX_PRINT_BOARD_LIST=True`).

```CMake
add_subdirectory(../.. miosix EXCLUDE_FROM_ALL)
include(LinkTarget)
```

These includes the Miosix CMake project and provide the `miosix_link_target` function.

```CMake
add_executable(blinking_led simple.cpp)
miosix_link_target(blinking_led)
```

These create a new target named `blinking_led` with the source file `simple.cpp` and links the miosix library.

You can now build your code on the board with these two commands:

```bash
cmake -Bbuild -DCMAKE_TOOLCHAIN_FILE=../../cmake/Toolchains/gcc.cmake
cmake --build build --target blinking_led
```

And if you also want to flash the code automatically on the board, you can run:

```bash
cmake --build build --target blinking_led_program
```

# TODOs

- [ ] Review MxGui build system
- [ ] Review TsCpp build system
- [ ] Properly handle MxGui examples (how do we build them?)
- [ ] Test debugger setup

Related pull requests:
- https://github.com/fedetft/tscpp/pull/1
- https://github.com/fedetft/mxgui/pull/3