### PR TITLE
Add Docker-based compiler build system

### DIFF
--- a/miosix/_tools/compiler/Dockerfile
+++ b/miosix/_tools/compiler/Dockerfile
@@ -1,0 +1,30 @@
+# ==========================================
+# Stage 1: build toolchain
+# ==========================================
+FROM ubuntu:20.04 AS builder
+
+ARG COMPILER
+ENV COMPILER=${COMPILER}
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && apt -y install \
+    gcc g++ make libncurses5-dev byacc flex texinfo patch tar unzip lzip \
+    libelf-dev perl libexpat1-dev curl xz-utils sudo
+
+# Copy only the selected subdirectory
+COPY ${COMPILER} /project/${COMPILER}
+
+WORKDIR /project/${COMPILER}
+
+RUN ./download.sh && ./install-script.sh -j$(nproc)
+
+WORKDIR /opt
+RUN tar -zcvf arm-miosix-eabi-${COMPILER}.tar.gz arm-miosix-eabi
+
+# ==========================================
+# Stage 2: export artifact
+# ==========================================
+FROM scratch AS export
+ARG COMPILER
+COPY --from=builder /opt/arm-miosix-eabi-${COMPILER}.tar.gz /

--- a/miosix/_tools/compiler/build_with_docker.sh
+++ b/miosix/_tools/compiler/build_with_docker.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+# Script must be run from the compiler directory.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+list_compilers() {
+    find . -maxdepth 1 -type d -name "gcc-*" -printf "%f\n" | sort
+}
+
+# Select compiler
+if [[ $# -ge 1 ]]; then
+    COMPILER="$1"
+else
+    echo "Available compilers:"
+    list_compilers
+    echo ""
+    read -p "Select compiler: " COMPILER
+fi
+
+# Validate
+if [[ ! -d "$COMPILER" ]]; then
+    echo "Error: directory '$COMPILER' does not exist."
+    exit 1
+fi
+
+echo "Using compiler: $COMPILER"
+echo ""
+
+# Build using Dockerfile in this directory
+docker build \
+    --build-arg COMPILER="$COMPILER" \
+    --output "$SCRIPT_DIR" \
+    -t toolchain-builder:"$COMPILER" \
+    "$SCRIPT_DIR"


### PR DESCRIPTION
This PR introduces a Dockerfile and a helper script that allow building any supported compiler toolchain in a fully reproducible Docker environment. Once Docker completes the build, it automatically packages the resulting toolchain into a tar.gz archive, which is written directly inside the compiler/ directory.

This makes compiler builds reproducible, isolated from the host environment and easy to run with a single command.
The system has been tested only on Linux so far.

### Usage example
```
$ cd miosix/_tools/compiler
$ ./build_with_docker.sh gcc-15.2.0-mp4.0
# Wait until the build completes

$ ls -l *.tar.gz
-rw-r--r-- 1 al al 261922888  9 dic 15:39 arm-miosix-eabi-gcc-15.2.0-mp4.0.tar.gz
```

### What's included

- Dockerfile: defines a multi-stage build that downloads, builds, packages the toolchain and writes the output archive into the current compiler/ directory.
- build_with_docker.sh: helper script that: lets you choose a compiler folder and runs the Docker build 